### PR TITLE
[patch] make RoundTripDetailView scrollable

### DIFF
--- a/app/src/main/java/io/branch/branchlinksimulator/RoundTripStore.kt
+++ b/app/src/main/java/io/branch/branchlinksimulator/RoundTripStore.kt
@@ -5,7 +5,7 @@ import android.content.SharedPreferences
 import io.branch.interfaces.IBranchLoggingCallbacks
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
+import kotlinx.serialization.json.*
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -24,6 +24,8 @@ class RoundTripStore(context: Context) : IBranchLoggingCallbacks {
     val roundTrips: StateFlow<List<RoundTrip>> = _roundTrips
 
     private val FAILED = "failed to parse"
+
+    private val json = Json { prettyPrint = true }
 
     override fun onBranchLog(logMessage: String?, severityConstantName: String?) {
         scope.launch(Dispatchers.Main) {
@@ -89,10 +91,15 @@ class RoundTripStore(context: Context) : IBranchLoggingCallbacks {
         return regex.find(log)?.value
     }
 
+    private fun String.prettyPrint(): String {
+        val jsonElement = json.parseToJsonElement(this)
+        return json.encodeToString(jsonElement)
+    }
+
     private fun parseBody(log: String, identifier: String): String? {
         val bodyStart = log.indexOf(identifier).takeIf { it != -1 }?.let { it + identifier.length }
         return bodyStart?.let {
-            log.substring(it).trim()
+            log.substring(it).trim().prettyPrint()
         }
     }
 

--- a/app/src/main/java/io/branch/branchlinksimulator/RoundTripsView.kt
+++ b/app/src/main/java/io/branch/branchlinksimulator/RoundTripsView.kt
@@ -99,16 +99,34 @@ fun RoundTripDetailView(roundTrip: RoundTrip) {
             .fillMaxSize()
             .padding(16.dp)
     ) {
-        VariableView(label = "URL", value = roundTrip.url)
-        Spacer(modifier = Modifier.height(8.dp))
-        Text("Request", style = MaterialTheme.typography.titleMedium, color = MaterialTheme.colorScheme.primary)
-        VariableView(label = "Body", value = roundTrip.request?.body ?: "FAILED")
-        Spacer(modifier = Modifier.height(16.dp))
-        roundTrip.response?.let {
-            Text("Response", style = MaterialTheme.typography.titleMedium, color = MaterialTheme.colorScheme.primary)
-            Text("Status Code: ${it.statusCode}", style = MaterialTheme.typography.titleSmall, color = Color.White)
-            VariableView(label = "Body", value = it.body)
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+        ) {
+            item {
+                VariableView(label = "URL", value = roundTrip.url)
+            }
+            item {
+                Spacer(modifier = Modifier.height(8.dp))
+            }
+            item {
+                Text("Request", style = MaterialTheme.typography.titleMedium, color = MaterialTheme.colorScheme.primary)
+            }
+            item {
+                VariableView(label = "Body", value = roundTrip.request?.body ?: "FAILED")
+            }
+            item {
+                Spacer(modifier = Modifier.height(16.dp))
+            }
+            item {
+                roundTrip.response?.let {
+                    Text("Response", style = MaterialTheme.typography.titleMedium, color = MaterialTheme.colorScheme.primary)
+                    Text("Status Code: ${it.statusCode}", style = MaterialTheme.typography.titleSmall, color = Color.White)
+                    VariableView(label = "Body", value = it.body)
+                }
+            }
         }
+
     }
 }
 


### PR DESCRIPTION
Wraps in a lazycolumn with items so that it is scrollable. On large payloads you couldnt see the whole thing which is annyoing

Additionally, pretty prints the json so that it is easier to read