### PR TITLE
[EMT-2503] Add async implementation build to run through test suite for release

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -83,9 +83,9 @@ dependencies {
     implementation ("com.android.support.constraint:constraint-layout:1.1.3")
 
 
-    //implementation("io.branch.sdk.android:library:5.18.1")
+    implementation("io.branch.sdk.android:library:5.20.3")
     // This branch assumes CI will place aar here
-    implementation(files("libs/branch-sdk-debug.aar"))
+    //implementation(files("libs/branch-sdk-debug.aar"))
 
 
     implementation("com.google.android.gms:play-services-ads-identifier:18.0.1")

--- a/app/src/androidTest/java/io/branch/branchlinksimulator/BranchBackgroundInitTest.kt
+++ b/app/src/androidTest/java/io/branch/branchlinksimulator/BranchBackgroundInitTest.kt
@@ -1,0 +1,39 @@
+package io.branch.branchlinksimulator
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.branch.referral.Branch
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.junit.Test
+import org.junit.runner.RunWith
+
+val branchInitializationSignal = CompletableDeferred<Unit>()
+private val applicationJob = SupervisorJob()
+val applicationScope = CoroutineScope(Dispatchers.Main + applicationJob)
+val exampleBranchKey = "key_live_hshD4wiPK2sSxfkZqkH30ggmyBfmGmD7"
+
+@RunWith(AndroidJUnit4::class)
+class BranchBackgroundInitTest {
+
+    private val appContext: Context = ApplicationProvider.getApplicationContext()
+    @Test
+    fun branchGetInstanceTest() {
+        suspend fun backgroundGetBranchAutoInstanceTest(context: Context, branchKey: String) {
+            withContext(Dispatchers.IO) {
+                Branch.getAutoInstance(context, branchKey)
+            }
+            branchInitializationSignal.complete(Unit)
+        }
+
+        applicationScope.launch {
+            backgroundGetBranchAutoInstanceTest(appContext, exampleBranchKey)
+        }
+    }
+
+}

--- a/app/src/main/java/io/branch/branchlinksimulator/BranchLinkSimulatorApplication.kt
+++ b/app/src/main/java/io/branch/branchlinksimulator/BranchLinkSimulatorApplication.kt
@@ -2,13 +2,25 @@ package io.branch.branchlinksimulator
 
 import android.app.Application
 import android.content.Context
+import android.util.Log
 import io.branch.referral.Branch
+import kotlinx.coroutines.CompletableDeferred
 import java.util.UUID
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 class BranchLinkSimulatorApplication: Application() {
     lateinit var currentConfig: ApiConfiguration
     lateinit var roundTripStore: RoundTripStore
         private set
+
+    private val applicationJob = SupervisorJob()
+    val applicationScope = CoroutineScope(Dispatchers.Main + applicationJob)
+    val branchInitializationSignal = CompletableDeferred<Unit>()
 
     override fun onCreate() {
         super.onCreate()
@@ -21,7 +33,7 @@ class BranchLinkSimulatorApplication: Application() {
         roundTripStore = RoundTripStore(this)
         Branch.enableLogging(roundTripStore)
         // Branch object initialization
-        Branch.getAutoInstance(this, currentConfig.branchKey)
+        // Branch.getAutoInstance(this, currentConfig.branchKey)
 
         // Retrieve or create the bls_session_id
         val sharedPreferences = getSharedPreferences("branch_session_prefs", Context.MODE_PRIVATE)
@@ -30,8 +42,28 @@ class BranchLinkSimulatorApplication: Application() {
             sharedPreferences.edit().putString("bls_session_id", newId).apply()
             newId
         }
+        Log.d("AppScopeTest", "Application Fired launching coroutine")
+        applicationScope.launch {
+            Log.e("AppScopeTest", "Coroutine Successfully fired")
+            setupBranchInstance(this@BranchLinkSimulatorApplication, currentConfig.branchKey)
 
-        // Set the bls_session_id in Branch request metadata
-        Branch.getInstance().setRequestMetadata("bls_session_id", blsSessionId)
+            withContext(Dispatchers.Main) {
+
+                // Set the bls_session_id in Branch request metadata
+                Branch.getInstance().setRequestMetadata("bls_session_id", blsSessionId)
+            }
+        }
+    }
+
+    override fun onTerminate() {
+        super.onTerminate()
+        applicationJob.cancel()
+    }
+
+    suspend fun setupBranchInstance(context: Context, branchKey: String) {
+        withContext(Dispatchers.IO) {
+            Branch.getAutoInstance(context, branchKey)
+        }
+        branchInitializationSignal.complete(Unit)
     }
 }

--- a/app/src/main/java/io/branch/branchlinksimulator/BranchLinkSimulatorApplication.kt
+++ b/app/src/main/java/io/branch/branchlinksimulator/BranchLinkSimulatorApplication.kt
@@ -32,8 +32,6 @@ class BranchLinkSimulatorApplication: Application() {
 
         roundTripStore = RoundTripStore(this)
         Branch.enableLogging(roundTripStore)
-        // Branch object initialization
-        // Branch.getAutoInstance(this, currentConfig.branchKey)
 
         // Retrieve or create the bls_session_id
         val sharedPreferences = getSharedPreferences("branch_session_prefs", Context.MODE_PRIVATE)
@@ -42,13 +40,10 @@ class BranchLinkSimulatorApplication: Application() {
             sharedPreferences.edit().putString("bls_session_id", newId).apply()
             newId
         }
-        Log.d("AppScopeTest", "Application Fired launching coroutine")
         applicationScope.launch {
-            Log.e("AppScopeTest", "Coroutine Successfully fired")
+            // Coroutine used to move creating the Branch singleton through Branch.getAutoInstance() to background thread
             setupBranchInstance(this@BranchLinkSimulatorApplication, currentConfig.branchKey)
-
             withContext(Dispatchers.Main) {
-
                 // Set the bls_session_id in Branch request metadata
                 Branch.getInstance().setRequestMetadata("bls_session_id", blsSessionId)
             }
@@ -62,6 +57,7 @@ class BranchLinkSimulatorApplication: Application() {
 
     suspend fun setupBranchInstance(context: Context, branchKey: String) {
         withContext(Dispatchers.IO) {
+            // Branch object initialization
             Branch.getAutoInstance(context, branchKey)
         }
         branchInitializationSignal.complete(Unit)

--- a/app/src/main/java/io/branch/branchlinksimulator/MainActivity.kt
+++ b/app/src/main/java/io/branch/branchlinksimulator/MainActivity.kt
@@ -120,6 +120,8 @@ class MainActivity : ComponentActivity() {
         }
 
         lifecycleScope.launch {
+            val app = application as BranchLinkSimulatorApplication
+            app.branchInitializationSignal.await()
             val initErrorMessage = initializeBranch()
             initErrorMessageState.value = initErrorMessage
         }


### PR DESCRIPTION
Changes:

- Created coroutine to move Branch.getAutoInstance() to background thread within the BranchLinkSimulatorApplication.kt class.
- Added await to MainActivity in order to pause Branch Initialization until completing Branch.getAutoInstance() singleton.


Testing:

- Run app and initialize Branch. Ensure app doesn't crash.
- Send some events to test Branch functionality.
- Check logs for successful event and initialization data.
- Re-run app to ensure no crashes on subsequent opens.