### PR TITLE
[other] NO-TICKET: Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @BranchMetrics/engmt-eng
+* @BranchMetrics/engmt-eng @BranchMetrics/saas-sdk-devs

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @BranchMetrics/engmt-eng


### PR DESCRIPTION
Assigns ownership via CODEOWNERS (* @BranchMetrics/engmt-eng) as part of the service-catalogue rollout.